### PR TITLE
introduce holdCharge

### DIFF
--- a/nodes/evoptBatteryMode.html
+++ b/nodes/evoptBatteryMode.html
@@ -106,7 +106,7 @@
     <ul>
         <li><b>charge</b> - Netzladung: wenn charging_power > 0 UND grid_import > 0</li>
         <li><b>hold</b> - Batterie pausiert: wenn charging_power = 0 UND discharging_power = 0 (Entladung zurückgehalten)</li>
-        <li><b>holdcharge</b> - <i>nur bei aktivem HoldCharge-Modus:</i> Leerlauf bei Einspeisung (grid_export > 0) - Laden zurückgehalten, Entladung erlaubt</li>
+        <li><b>holdcharge</b> - <i>nur bei aktivem HoldCharge-Modus:</i> Leerlauf mit Einspeisung: wenn charging_power = 0 UND discharging_power = 0 UND grid_export > 0 (Laden zurückgehalten; nachgelagerte Controller können Entladung erlauben)</li>
         <li><b>normal</b> - Normalbetrieb: PV-Ladung oder Entladung für Hausverbrauch (alle anderen Fälle)</li>
     </ul>
     <p><b>Hinweise:</b></p>

--- a/nodes/evoptBatteryMode.html
+++ b/nodes/evoptBatteryMode.html
@@ -17,6 +17,9 @@
 			},
 			timeIndex : {
 				value : 0
+			},
+			holdCharge : {
+				value : false
 			}
 		},
 		inputs : 1,
@@ -51,6 +54,11 @@
         <label for="node-input-timeIndex"><i class="fa fa-clock-o"></i> Time Index</label>
         <input type="number" id="node-input-timeIndex" placeholder="0" min="0" class="input-typed"/>
     </div>
+    <div class="form-row">
+        <label for="node-input-holdCharge" style="width:auto"><i class="fa fa-toggle-on"></i> HoldCharge-Modus</label>
+        <input type="checkbox" id="node-input-holdCharge" style="display:inline-block; width:auto; vertical-align:top; margin-right:6px"/>
+        <span>idle + Einspeisung &rarr; <code>holdcharge</code> statt <code>hold</code></span>
+    </div>
 </script>
 
 <script type="text/x-red"
@@ -63,6 +71,7 @@
         <li><b>Battery Name</b> - Name der Batterie (z.B. "db:5") - wird priorisiert wenn angegeben</li>
         <li><b>Battery Index</b> - Alternativ: Index der Batterie im evopt.res.batteries Array (Standard: 0 wenn Name nicht angegeben)</li>
         <li><b>Time Index</b> - Zeitindex für die Vorhersage (0 = aktueller Zeitpunkt, Standard: 0)</li>
+        <li><b>HoldCharge-Modus</b> - Opt-in (Standard: aus). Wenn aktiv, liefert der Node im Leerlauf bei Einspeisung den Modus <code>holdcharge</code> (Laden zurückhalten) statt <code>hold</code> - passend zur evcc evopt-Suggestion. <b style="color:#ff9800;">Achtung:</b> nachgelagerte Nodes (z.B. controlBattery, batteryModeControl) müssen <code>holdcharge</code> dann kennen, sonst greift dort der Fallback. Default aus = unverändertes Verhalten.</li>
     </ul>
     <p><b>Inputs:</b></p>
     <ul>
@@ -72,7 +81,7 @@
     <ul>
         <li><b>Output 1: Battery Mode</b> - Batteriemodus-Informationen
             <ul>
-                <li><code>payload</code> - Batteriemodus als String: "charge", "hold" oder "normal"</li>
+                <li><code>payload</code> - Batteriemodus als String: "charge", "hold", "normal" (und "holdcharge", falls HoldCharge-Modus aktiv)</li>
                 <li><code>batterymode</code> - Batteriemodus</li>
                 <li><code>chargingPower</code> - Ladeleistung in Watt</li>
                 <li><code>dischargingPower</code> - Entladeleistung in Watt</li>
@@ -96,7 +105,8 @@
     <p><b>Batteriemodus-Logik:</b></p>
     <ul>
         <li><b>charge</b> - Netzladung: wenn charging_power > 0 UND grid_import > 0</li>
-        <li><b>hold</b> - Batterie pausiert: wenn charging_power = 0 UND discharging_power = 0</li>
+        <li><b>hold</b> - Batterie pausiert: wenn charging_power = 0 UND discharging_power = 0 (Entladung zurückgehalten)</li>
+        <li><b>holdcharge</b> - <i>nur bei aktivem HoldCharge-Modus:</i> Leerlauf bei Einspeisung (grid_export > 0) - Laden zurückgehalten, Entladung erlaubt</li>
         <li><b>normal</b> - Normalbetrieb: PV-Ladung oder Entladung für Hausverbrauch (alle anderen Fälle)</li>
     </ul>
     <p><b>Hinweise:</b></p>

--- a/nodes/evoptBatteryMode.js
+++ b/nodes/evoptBatteryMode.js
@@ -8,6 +8,9 @@ module.exports = function (RED) {
         node.batteryIndex = config.batteryIndex !== undefined ? parseInt(config.batteryIndex) : null;
         node.batteryName = config.batteryName || "";
         node.timeIndex = parseInt(config.timeIndex) || 0;
+        // Opt-in: distinguish withholding charge (idle + export) as "holdcharge".
+        // Default off so downstream nodes that only know charge/hold/normal are unaffected.
+        node.holdCharge = config.holdCharge === true || config.holdCharge === "true";
         let debug = false;
 
         node.on("input", async function (msg) {
@@ -98,8 +101,14 @@ module.exports = function (RED) {
                     // Battery is charging from grid
                     batteryMode = "charge";
                 } else if (chargingPower === 0 && dischargingPower === 0) {
-                    // Battery is not being used
-                    batteryMode = "hold";
+                    // Idle. With holdCharge enabled, mirror evcc's evopt suggestion:
+                    // idle while exporting means charging is deliberately withheld
+                    // (holdcharge); otherwise hold (withhold discharge).
+                    if (node.holdCharge && gridExportValue > 0) {
+                        batteryMode = "holdcharge";
+                    } else {
+                        batteryMode = "hold";
+                    }
                 } else {
                     // All other cases: PV charging, normal discharge for household
                     batteryMode = "normal";
@@ -159,6 +168,9 @@ module.exports = function (RED) {
                     case "hold":
                         node.status({ fill: "yellow", shape: "dot", text: "hold" });
                         break;
+                    case "holdcharge":
+                        node.status({ fill: "yellow", shape: "ring", text: `holdcharge (export ${gridExportValue}W)` });
+                        break;
                     case "normal":
                         if (chargingPower > 0) {
                             node.status({ fill: "green", shape: "dot", text: `normal (charging ${chargingPower}W from PV)` });
@@ -188,6 +200,7 @@ module.exports = function (RED) {
             url: { value: "http://controller:7070/api/state" },
             batteryIndex: { value: 0 },
             timeIndex: { value: 0 },
+            holdCharge: { value: false },
         },
         outputs: 3,
         outputLabels: ["Battery Mode", "SOC Information", "Full evopt Data"],


### PR DESCRIPTION
## Summary by Sourcery

Add an optional HoldCharge mode to the evoptBatteryMode node to distinguish withheld charging during export from generic battery hold state.

New Features:
- Introduce configurable HoldCharge mode that maps idle + grid export to a new battery mode value holdcharge.
- Expose a HoldCharge-Modus checkbox in the evoptBatteryMode node UI, defaulting to off, and document its behavior and implications for downstream nodes.

Enhancements:
- Extend battery mode status display to show a distinct visual indicator when in holdcharge mode.
- Update battery mode documentation to include the new holdcharge state and clarify semantics of hold vs holdcharge.