### PR TITLE
Release 0.2.1 (version bump for tag/publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iseeberg79/battery-usage-optimization-nodes",
-    "version": "0.2.1-1",
+    "version": "0.2.1",
     "description": "A custom Node-RED package for battery usage optimization",
     "main": "ControlBattery.js",
     "scripts": {


### PR DESCRIPTION
Bumps `package.json` from `0.2.1-1` → **`0.2.1`** so it matches the release tag.

## Why
The existing GitHub Release **v0.2.1 / tag `0.2.1`** failed to publish: the publish workflow checks `package.json == tag` exactly, but the tagged commit still carried `0.2.1-1`, so npm was never updated (still on `0.2.0-21`).

## After merge
1. Move tag `0.2.1` to the merged commit (or delete + recreate the release targeting `main`).
2. Re-trigger the Publish workflow → npm gets `0.2.1`.

Ships the configurable open-meteo model (default `icon_seamless`) from #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)