### PR TITLE
ci(publish): grant id-token:write for npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
The Publish workflow runs `npm publish --provenance`, but the job has no `id-token: write` permission, so every release fails at the publish step:

```
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

This is why the **v0.2.1** release did not reach npm (registry still on `0.2.0-21`). Adds the required permissions (`id-token: write` + `contents: read`).

After merge: re-cut the `0.2.1` release so the fixed workflow runs and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Grant the publish workflow the necessary GitHub Actions permissions to successfully run npm provenance publishing.

Build:
- Update the publish GitHub Actions workflow to include contents: read and id-token: write permissions required by npm publish --provenance.

CI:
- Adjust the publish CI workflow permissions so npm publish with provenance can complete without permission errors.