### PR TITLE
ci(publish): npm trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,15 @@ jobs:
         fi
         echo "✅ Version matches release tag"
 
+    # Trusted Publishing (OIDC) needs npm >= 11.5.1; node 20 ships npm 10.
+    - name: Upgrade npm for trusted publishing
+      run: npm install -g npm@latest
+
+    # No NODE_AUTH_TOKEN: authenticates via OIDC against the trusted
+    # publisher configured for this package on npmjs.com. Provenance is
+    # generated automatically.
     - name: Publish to npm
-      run: npm publish --provenance
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish
 
     - name: Create package artifact
       run: npm pack


### PR DESCRIPTION
Switches the Publish workflow from a long-lived `NPM_TOKEN` to npm **Trusted Publishing** (OIDC), as npm now recommends for CI/CD.

## Why
The `NPM_TOKEN` secret expired (last successful publish was 0.2.0-21 on 2025-11-16), so every release since fails with `PUT 404`. Trusted Publishing removes the token entirely — auth happens via short-lived OIDC exchange, no secret to rotate/expire.

## Changes
- Upgrade npm to `>= 11.5.1` (node 20 ships npm 10; OIDC publishing needs 11.5.1+).
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN`.
- Keep `id-token: write` (already added in #61). Provenance is now generated automatically.

## Required one-time setup on npmjs.com (maintainer action)
Package → **Settings → Trusted Publisher → GitHub Actions**:
- Repository: `iseeberg79/battery-usage-optimization-nodes`
- Workflow filename: `publish.yml`
- Environment: *(leave empty)*

After that + merge: re-cut the `0.2.1` release → publishes via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the publish GitHub Actions workflow to upgrade npm before publishing and rely on OIDC-based trusted publishing without NODE_AUTH_TOKEN/NPM_TOKEN.