### PR TITLE
ci(publish): drop registry-url so OIDC works (placeholder token shadowed it)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    # No registry-url: it would write an .npmrc with a placeholder _authToken,
+    # which npm uses instead of OIDC and fails with 404. The default registry
+    # is registry.npmjs.org, which trusted publishing targets via OIDC.
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
 
     - name: Install dependencies
@@ -52,7 +54,9 @@ jobs:
 
     # Trusted Publishing (OIDC) needs npm >= 11.5.1; node 20 ships npm 10.
     - name: Upgrade npm for trusted publishing
-      run: npm install -g npm@latest
+      run: |
+        npm install -g npm@latest
+        npm --version
 
     # No NODE_AUTH_TOKEN: authenticates via OIDC against the trusted
     # publisher configured for this package on npmjs.com. Provenance is


### PR DESCRIPTION
The trusted-publishing run still failed with `PUT 404`. Root cause: `actions/setup-node` with `registry-url` writes an `.npmrc` with a **placeholder** `_authToken=XXXXX-XXXXX-XXXXX-XXXXX`. npm sends that bogus token instead of using OIDC → 404.

Fix: remove `registry-url` (default registry is `registry.npmjs.org`, which OIDC targets). No token is written, so npm ≥ 11.5.1 uses trusted publishing. Also print `npm --version` to confirm the upgrade is in effect.

After merge: re-cut `0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update publish CI workflow to rely on npm trusted publishing via OIDC without registry-specific auth configuration.

CI:
- Remove explicit npm registry-url configuration from the publish workflow to avoid placeholder token conflicts with OIDC trusted publishing.
- Print the npm version after upgrading in the publish workflow to verify the required version for trusted publishing is in use.