### PR TITLE
Update test.yml to save budget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,17 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary by Sourcery

Limit CI test workflow concurrency and reduce Node.js versions tested to lower resource usage.

CI:
- Add workflow-level concurrency configuration to cancel in-progress runs for the same ref.
- Reduce test matrix to run only on Node.js 20.x and 22.x instead of 18.x, 20.x, and 22.x.