### PR TITLE
controlBattery: unbekannte evcc-Batteriemodi tolerieren

### DIFF
--- a/nodes/controlBattery.js
+++ b/nodes/controlBattery.js
@@ -166,6 +166,19 @@ module.exports = function (RED) {
                         outputs[1] = { payload: msg.targetMode, optimize: msg.optimize };
                         node.status({ fill: "orange", shape: "dot", text: msg.targetMode });
                     }
+
+                    // Kompatibilitäts-Guard: neuere evcc-Versionen kennen weitere Batteriemodi
+                    // (z. B. "holdcharge", perspektivisch "discharge"), die dieser Node (noch) nicht
+                    // aktiv steuert. Statt unbemerkt keinen Output zu erzeugen und die "changed"-
+                    // Erkennung unten fälschlich anschlagen zu lassen, wird der Modus nur angezeigt.
+                    if (!["charge", "unknown", "normal", "hold"].includes(msg.evccBatteryMode)) {
+                        if (debug) {
+                            node.warn(`Unbekannter EVCC Battery Mode: ${msg.evccBatteryMode} - keine Steuerung, nur Anzeige`);
+                        }
+                        msg.targetMode = msg.evccBatteryMode;
+                        node.status({ fill: "grey", shape: "ring", text: msg.targetMode });
+                    }
+
                     outputs[3] = msg;
                 } else {
                     node.warn("UI Sperre: forcierte Batteriesperre!");


### PR DESCRIPTION
## Kontext
evcc kennt seit [evcc-io/evcc#27906](https://github.com/evcc-io/evcc/pull/27906) (gemerged 2026-06-07) den zusätzlichen Batteriemodus `holdcharge` (neben `unknown`/`normal`/`hold`/`charge`), inzwischen für diverse Wechselrichter (Kostal, RCT, Huawei, SMA, Marstek, Atmoce) implementiert. Ein spiegelbildlicher `discharge`-Modus zeichnet sich ab, ist aber noch nicht Teil der evcc-API.

Geprüft wurde außerdem PR [evcc-io/evcc#32490](https://github.com/evcc-io/evcc/pull/32490) ("Mode Redesign: rename pv to smart, replace minpv with always charge") – diese betrifft ausschließlich den EV-Ladepunkt-Modus (`/api/loadpoints/{id}/mode`), nicht den hier genutzten Hausbatterie-Modus (`/api/batterymode`). Kein Anpassungsbedarf.

## Änderung
`nodes/controlBattery.js`: Meldete evcc bisher einen Modus außerhalb von `charge`/`unknown`/`normal`/`hold` (z. B. `holdcharge`), griff keiner der bestehenden Zweige – kein Status-Update, und die `changed`-Erkennung am Ende der Funktion konnte fälschlich anschlagen. Ein neuer Guard zeigt solche Modi nur an (grauer Status), ohne aktiv zu steuern.

Damit ist der Node sowohl gegenüber älteren evcc-Versionen (kennen `holdcharge` nicht) als auch neueren (melden es ggf.) robust – ohne fachliche Steuerungslogik für den neuen Modus vorwegzunehmen.

Die Steuerungs-Whitelist in `batteryModeControl.js` (`["unknown", "normal", "hold", "charge"]`) bleibt bewusst unverändert – es wird also weiterhin nicht aktiv `holdcharge` gesetzt.

## Tests
Bestehende Test-Suite läuft weiterhin grün (`npx jest`, 26/26). Für `controlBattery.js` existiert aktuell keine eigene Testdatei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle previously unsupported evcc battery modes more robustly in the controlBattery node to avoid incorrect change detection and ensure they are surfaced in the UI without being actively controlled.

Bug Fixes:
- Prevent missed status updates and spurious change detection when evcc reports a battery mode outside the existing charge/unknown/normal/hold set.

Enhancements:
- Display unsupported or future evcc battery modes (e.g. holdcharge) in the controlBattery node with a neutral status while keeping control limited to the known modes.